### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/doc/ppt/jmpress.js-master/src/plugins/presentation-mode.js
+++ b/doc/ppt/jmpress.js-master/src/plugins/presentation-mode.js
@@ -34,7 +34,7 @@
 
 			window.addEventListener("message", function(event) {
 				// We do not test orgin, because we want to accept messages
-				// from all orgins
+				// from all origins
 				try {
 					if(typeof event.data !== "string" || event.data.indexOf(PREFIX) !== 0) {
 						return;

--- a/doc/ppt/js/impress.js
+++ b/doc/ppt/js/impress.js
@@ -606,7 +606,7 @@
             // scrolling to element in hash.
             //
             // And it has to be set after animation finishes, because in Chrome it
-            // makes transtion laggy.
+            // makes transition laggy.
             // BUG: http://code.google.com/p/chromium/issues/detail?id=62820
             root.addEventListener("impress:stepenter", function (event) {
                 window.location.hash = lastHash = "#/" + event.target.id;


### PR DESCRIPTION
There are small typos in:
- doc/ppt/jmpress.js-master/src/plugins/presentation-mode.js
- doc/ppt/js/impress.js

Fixes:
- Should read `transition` rather than `transtion`.
- Should read `origins` rather than `orgins`.

Closes #13